### PR TITLE
Fix error: Cannot use object of type stdClass as array

### DIFF
--- a/src/DI/SupervisorExtension.php
+++ b/src/DI/SupervisorExtension.php
@@ -19,7 +19,7 @@ final class SupervisorExtension extends CompilerExtension
 	{
 		$builder = $this->getContainerBuilder();
 
-		$config = $this->getConfig();
+		$config = (array) $this->getConfig();
 
 		if ( ! isset($config['prefix'])) {
 			throw new \Pd\Supervisor\DI\MissingConfigurationValueException(


### PR DESCRIPTION
![DeepinScreenshot_select-area_20210616100440](https://user-images.githubusercontent.com/13538235/122182214-5f067700-ce8a-11eb-9288-7f5529effa10.png)
